### PR TITLE
Fix build issues on Android related to versioning

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -22,4 +22,8 @@ storeFile=../key.jks
 
 Where you set the `storePassword` and the `keyPassword`. You can also change the alias.
 
+You will need to uncomment the section `signingConfigs` in the `app/build.gradle`.
+
+And change the `signingConfig signingConfigs.debug` to `signingConfig signingConfigs.release`.
+
 You can also provide this files from your CI instead of including this in the project.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,8 +47,7 @@ android {
         minSdkVersion 21 // avoid max 64k method limit
         targetSdkVersion 28
 
-        def (majorNum, minorNum, buildNum) = flutterVersionName.tokenize( '.' )
-        versionCode majorNum.toInteger() * 1_000_000 + minorNum.toInteger() * 1_000 + buildNum.toInteger()
+        versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -53,14 +53,15 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
-    signingConfigs {
-        release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-        }
-    }
+//     signingConfigs {
+//         release {
+//             keyAlias keystoreProperties['keyAlias']
+//             keyPassword keystoreProperties['keyPassword']
+//             storeFile file(keystoreProperties['storeFile'])
+//             storePassword keystoreProperties['storePassword']
+//         }
+//     }
+
     buildTypes {
         debug {
             // app id will be "de.janoodle.circlesApp.debug"
@@ -69,7 +70,7 @@ android {
         release {
             // NOTE: ProGuard is not enabled at the moment
             // See: https://flutter.dev/docs/deployment/android to enable it
-            signingConfig signingConfigs.release
+            signingConfig signingConfigs.debug
         }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ description: Timy group messaging app
 # In Android, build-name is used as versionName while build-number used as versionCode.
 # Read more about Android versioning at https://developer.android.com/studio/publish/versioning
 
-version: 1.0.23+1
+version: 1.0.0+1
 
 environment:
   sdk: ">=2.2.2 <3.0.0"


### PR DESCRIPTION
Fixes #1 

Also changes the signing keys to be debug by default.
Android deploy instructions have been updated too.