### PR TITLE
Added google-services.json to gitignore for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 **/android/gradlew.bat
 **/android/local.properties
 **/android/**/GeneratedPluginRegistrant.java
+**/android/**/google-services.json
 
 # iOS/XCode related
 **/ios/**/*.mode1v3


### PR DESCRIPTION
This PR updates the `.gitignore` adding the google-services.json.

This avoids adding Firebase config files to source control.