### PR TITLE
Added Firebase setup steps for android

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,11 +1,35 @@
 # Timy Android
 
-## Firebase
+## Setting up Firebase
 
-The Firebase configuration file `google-services.json` need to be provided and located inside the `android/src/main` folder.
+Create a project on the Firebase console [here](https://console.firebase.google.com/)
 
-If you want to have different configs for release and debug, 
-provide two different files in the `android/src/release` and `android/src/debug` folders.
+- To add Firebase to your app, click on the android icon or click the gear icon to go to project
+settings to find the android icon.
+
+- Register your application by filing up the form with the package name (applicationId) 
+and the app nickname if you like.
+> Find Your package name which is generally the applicationId in your app-level build.gradle file
+
+- Don't just download the `google-service.json` just yet, click next throughout and also skip the
+step where you need to verify the configuration.
+
+- Go back to project settings, here we need to generate a second configuration file. The reason for
+this is that the first file we generated is for a release build. Now we need to create one for a
+debug build. These applications are differentiated by the application id to which while debugging,
+a suffix `.debug` is appended to the applicationId.
+
+- Under your apps, add another app to the project. Click the android icon again on the dialog that
+pops up. Register your app with the package name with `.debug` at the end.
+
+- Download the `google-service.json` file that is generated for you. Find it and move it inside
+the folder `android/app/` of the project. The firebase sdk is already added to the project.
+
+- Open and view the contents of the file, check that there are 2 entries of `client_info` with the
+2 package names, one for debug and one for release.
+
+- On the fourth step of registration, run the app to verify the configuration via the Firebase
+console.
 
 ## Distribution
 


### PR DESCRIPTION
I prepared this while I implemented the steps. I hope they are verbose enough. The whole setup doesn't require any code alterations. Only files touched in the making of this PR are only the README, the added `google-service.json` from following the steps and the untracked files by successfully building both the debug build and a release build

resolves #16