### PR TITLE
Fix building project with Flutter Master Channel

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -9,7 +9,19 @@ settings to find the android icon.
 
 2. Register your application by filing up the form with the package name (applicationId) 
 and the app nickname if you like.
-> Find Your package name which is generally the applicationId in your app-level build.gradle file
+
+**Find Your package name which is generally the applicationId in your app-level build.gradle file**
+
+Default applicationId is: `de.janoodle.circlesApp`
+
+```groovy
+defaultConfig {
+    applicationId "de.janoodle.circlesApp"
+}
+```
+
+You may need to change it to `de.janoodle.circlesApp.debug` if you have configured the project
+that way.
 
 3. Download the `google-service.json` file that is generated for you. Find it and move it inside
 the folder `android/app/` of the project. The firebase sdk is already added to the project.
@@ -19,21 +31,7 @@ console.
 
 ## Distribution
 
-To build this application for distribution, 
-provide a file `key.jks` containing the signing keys, 
-and the `key.properties` with the following content:
+The Android signing process for Release builds has been removed.
 
-```
-storePassword=.....
-keyPassword=.....
-keyAlias=key
-storeFile=../key.jks
-```
+You will have to configure it manually.
 
-Where you set the `storePassword` and the `keyPassword`. You can also change the alias.
-
-You will need to uncomment the section `signingConfigs` in the `app/build.gradle`.
-
-And change the `signingConfig signingConfigs.debug` to `signingConfig signingConfigs.release`.
-
-You can also provide this files from your CI instead of including this in the project.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -261,10 +261,12 @@ packages:
   flutter_platform_widgets:
     dependency: "direct main"
     description:
-      name: flutter_platform_widgets
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.20.2"
+      path: "."
+      ref: "beta-1.10.7"
+      resolved-ref: ecfb97b63fcb193a4678708314ac436b22cfe9d4
+      url: "git://github.com/aqwert/flutter_platform_widgets.git"
+    source: git
+    version: "0.20.3-beta.1"
   flutter_redux:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,12 @@ dependencies:
       ref: fix/ios_compression
 
   pinch_zoom_image: ^0.2.5
-  flutter_platform_widgets: ^0.20.2
+
+  # TODO: Change this library to a stable version
+  flutter_platform_widgets:
+    git:
+      url: git://github.com/aqwert/flutter_platform_widgets.git
+      ref: beta-1.10.7
 
   flutter_linkify: ^2.1.0
   url_launcher: ^5.0.3


### PR DESCRIPTION
This PR fixed the requirements to build the app against Flutter's master channel (1.10.x).

To switch to master channel, run:

```
flutter channel master
flutter upgrade
```

The issue was the library https://github.com/aqwert/flutter_platform_widgets not being compatible with master channel and only being compatible with stable channel (1.9.x)

A fix provided in the branch https://github.com/aqwert/flutter_platform_widgets/tree/beta-1.10.7 made it work.

We would need to switch to a stable version of the library once Flutter 1.10 reaches master channel.
